### PR TITLE
feat: Enable internal power parsing in OpenTimer library

### DIFF
--- a/ot/liberty/celllib.cpp
+++ b/ot/liberty/celllib.cpp
@@ -1069,12 +1069,12 @@ namespace ot
         ccsn_stage.pin = cellpin.name;
         cellpin.ccsn_stages->push_back(ccsn_stage);
       }
-      // else if (*itr == "internal_power")
-      // {
-      //   // Extract internal power information
-      //   auto ip = _extract_internal_power(itr, end);
-      //   cellpin.internal_power.push_back(ip);
-      // }
+      else if (*itr == "internal_power")
+      {
+        // Extract internal power information
+        auto ip = _extract_internal_power(itr, end);
+        cellpin.internal_powers.push_back(ip);
+      }
       else if (*itr == "timing")
       {
         // Extract timing information

--- a/ot/liberty/cellpin.hpp
+++ b/ot/liberty/cellpin.hpp
@@ -61,6 +61,7 @@ namespace ot
     std::optional<bool> is_clock; // Is clock pin.
 
     std::vector<Timing> timings;
+    std::vector<InternalPower> internal_powers;
 
     std::optional<std::vector<CCSNStage>> ccsn_stages; // Optional list of CCSNStage objects
 


### PR DESCRIPTION
- Add internal_powers vector to Cellpin struct in cellpin.hpp
- Uncomment and fix internal_power parsing block in celllib.cpp
- Change internal_power.push_back() to internal_powers.push_back() (plural)

This enables the C++ parser to extract internal power information from Liberty files, including rise_power and fall_power NLDM tables with their associated when conditions. The parsed data is now stored in the Cellpin data structure for later consumption by Python bindings.

🤖 Generated with [Claude Code](https://claude.ai/code)